### PR TITLE
Upgrade the official termshark snap package to v2.3.0

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: termshark
-version: '2.2.0'
+version: '2.3.0'
 summary: A terminal UI for tshark, inspired by Wireshark 
 description: |
   A terminal UI for tshark, inspired by Wireshark.
@@ -15,12 +15,21 @@ parts:
     source-type: git
     build-environment:
       - GO111MODULE: 'on'
+      - CGO_ENABLED: '0'
+      - GOROOT: '/usr/local/go'
     override-pull: |
         echo "Skipping pull stage."
     override-build: |
         mkdir $SNAPCRAFT_PART_INSTALL/bin
         export GOBIN=$SNAPCRAFT_PART_INSTALL/bin
-        go get github.com/gcla/termshark/v2/cmd/termshark@88f03745cb23eb6aae02a1e2d0c6dc361d23db86
+        apt-get install wget
+        wget https://golang.org/dl/go1.17.linux-amd64.tar.gz
+        tar xvf go1.17.linux-amd64.tar.gz
+        mv go /usr/local/
+        git clone https://github.com/gcla/termshark.git
+        cd termshark
+        git checkout v2.3.0
+        /usr/local/go/bin/go install ./...
     build-packages:
       - gcc
     stage-packages:


### PR DESCRIPTION
This change does things a bit differently, for the following reasons:

- I want to build the binary with Go 1.17, for the free performance improvements.

- The snap packaging environment doesn't have Go 1.17, so the new packaging script downloads it and makes it available

- Furthermore, go install/get won't work as single line termshark builders any more because termshark uses replace directives in its go.mod
```
$ go install github.com/gcla/termshark/v2/cmd/termshark@latest
go install: github.com/gcla/termshark/v2/cmd/termshark@latest (in github.com/gcla/termshark/v2@v2.3.0):
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.
```
This is discussed here: https://github.com/golang/go/issues/40276

Longer-term, I need to remove these directives, or wait for a Go release that makes it possible to use them with go install. For now, I just git clone termshark and build it locally.